### PR TITLE
Fixtures GWB pour tests (small/medium/edge)

### DIFF
--- a/code/.gitignore
+++ b/code/.gitignore
@@ -17,3 +17,9 @@ geneweb/*.install
 geneweb/**/.ocamlformat
 geneweb/**/.coverage
 geneweb/**/.cache
+
+
+# Fixtures générées localement (à ignorer)
+tests/fixtures/gwb/small/demo_min/
+tests/fixtures/gwb/medium/demo_copy/
+tests/fixtures/gwb/edge/encodage_min/

--- a/code/tests/fixtures/gwb/README.md
+++ b/code/tests/fixtures/gwb/README.md
@@ -1,0 +1,20 @@
+# Fixtures GWB (GeneWeb Base)
+
+Ce dossier contient des bases GWB miniatures pour les tests.
+
+- small/: très petites bases (quelques individus/familles)
+- medium/: bases de taille moyenne (extraits de la démo)
+- edge/: cas tordus (encodages, champs manquants, structures minimales)
+
+Provenance:
+- Dérivées de la démo fournie par GeneWeb (distribution/bases/demo) et/ou reconstruites artificiellement.
+- Pas de données réelles sensibles.
+
+Règles:
+- Versionner uniquement des bases minimales nécessaires aux tests.
+- Documenter ici tout script ou processus de génération.
+
+Génération locale (exemple):
+- Copier la base de démo complète (non versionnée) pour référence:
+  - cp -R ../../../../geneweb/distribution/bases/demo ./medium/demo_full  # ignorer dans git
+- Créer une mini-base small/demo_min en ne gardant que les fichiers obligatoires (base, index minimaux) puis vérifier l’export gwb2ged.

--- a/code/tests/fixtures/gwb/edge/.keep
+++ b/code/tests/fixtures/gwb/edge/.keep
@@ -1,0 +1,1 @@
+# Structure des fixtures GWB

--- a/code/tests/fixtures/gwb/medium/.keep
+++ b/code/tests/fixtures/gwb/medium/.keep
@@ -1,0 +1,1 @@
+# Structure des fixtures GWB

--- a/code/tests/fixtures/gwb/small/.keep
+++ b/code/tests/fixtures/gwb/small/.keep
@@ -1,0 +1,1 @@
+# Structure des fixtures GWB

--- a/code/tools/make_fixtures.sh
+++ b/code/tools/make_fixtures.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Génère des mini-fixtures GWB à partir d'une base source
+# Usage: GENEWEB_OCAML_ROOT=/path/to/geneweb ./tools/make_fixtures.sh
+
+ROOT="${GENEWEB_OCAML_ROOT:-}"
+if [[ -z "$ROOT" ]]; then
+  echo "GENEWEB_OCAML_ROOT non défini" >&2
+  exit 1
+fi
+
+SRC_DEMO_BASE="$ROOT/distribution/bases/demo.gwb"
+DEST_DIR="tests/fixtures/gwb"
+
+if [[ ! -f "$SRC_DEMO_BASE/base" ]]; then
+  echo "Base de démo introuvable: $SRC_DEMO_BASE" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST_DIR/small/demo_min" "$DEST_DIR/medium/demo_copy" "$DEST_DIR/edge"
+
+# small/demo_min: copie minimale (uniquement base)
+cp -f "$SRC_DEMO_BASE/base" "$DEST_DIR/small/demo_min/base"
+
+# medium/demo_copy: copie plus large (base + quelques index si présents)
+cp -f "$SRC_DEMO_BASE/base" "$DEST_DIR/medium/demo_copy/base" || true
+for f in ind indn fam famn occ occn; do
+  [[ -f "$SRC_DEMO_BASE/$f" ]] && cp -f "$SRC_DEMO_BASE/$f" "$DEST_DIR/medium/demo_copy/$f"
+done
+
+# edge/encodage_min: base minimale avec caractères spéciaux (note: artificiel)
+EDGE_DIR="$DEST_DIR/edge/encodage_min"
+mkdir -p "$EDGE_DIR"
+# Crée un fichier base vide pour placeholder, à enrichir plus tard par générateur Python
+: > "$EDGE_DIR/base"
+
+echo "Fixtures générées dans $DEST_DIR"


### PR DESCRIPTION
Ajoute structure fixtures avec README et script make_fixtures.sh; dossiers vides avec .keep; ignore les données générées localement; permet tests rapides sans dépendre de la base complète.